### PR TITLE
Removed date column from the reviews table

### DIFF
--- a/core/reviews.js
+++ b/core/reviews.js
@@ -52,8 +52,7 @@ class Reviews {
         theme_id: theme.theme_id,
         store_title: $(el).find('.review-title__author').first().text(),
         description: $(el).find('.review__body').text(),
-        sentiment: Utilities.analyzeSentiment($(el).find('.review-graph__icon')),
-        date: Utilities.formatDate($(el).find('.review-title__date').text())
+        sentiment: Utilities.analyzeSentiment($(el).find('.review-graph__icon'))
       }
       reviewsFromPage = [...reviewsFromPage, review];
     });

--- a/core/utilities.js
+++ b/core/utilities.js
@@ -9,25 +9,6 @@ class Utilities {
     }
   }
   
-  static formatDate(el) {
-    const daysRegex = /(\d{1,2})\s(days?\sago)/;
-    const hoursRegex = /(\d{1,2})\s(hours?\sago)/;
-    const minutesRegex = /(\d{1,2})\s(minutes?\sago)/;
-  
-    if (daysRegex.test(el)) {
-      const numberOfDays = el.match(daysRegex)[1];
-      return new Date(Date.now() - (86400000 * numberOfDays))
-    } else if (hoursRegex.test(el)) {
-      const numberOfHours = el.match(hoursRegex)[1];
-      return new Date(Date.now() - (3600000 * numberOfHours));
-    } else if(minutesRegex.test(el)) {
-      const numberOfMinutes = el.match(minutesRegex)[1];
-      return new Date(Date.now() - (60000 * numberOfMinutes));
-    } else {
-      return new Date(el);
-    }
-  }
-
   static getTotalNumberOfPages($) {
     const numberOfPages = Number($('.next_page').prev().text());
     return numberOfPages > 0 ? numberOfPages : 1;

--- a/db/db-access.js
+++ b/db/db-access.js
@@ -58,7 +58,7 @@ const db = require('./index');
   
   static async getReviews(theme_id) {
     try {
-      const reviews = await db('reviews').where('theme_id', theme_id).orderBy('date', 'desc');
+      const reviews = await db('reviews').where('theme_id', theme_id);
       return reviews;
     } catch (error) {
       console.log(error);

--- a/db/migrations/20210109115416_remove_date_from_reviews.js
+++ b/db/migrations/20210109115416_remove_date_from_reviews.js
@@ -1,0 +1,8 @@
+
+exports.up = knex => knex.schema.alterTable('reviews', table => {
+  table.dropColumn('date');
+});
+
+exports.down = knex => knex.schema.alterTable('reviews', table => {
+  table.date('date');
+});

--- a/db/seeds/add_themes_to_themes.js
+++ b/db/seeds/add_themes_to_themes.js
@@ -1,7 +1,16 @@
 
 exports.seed = function(knex) {
   // Deletes ALL existing entries
-  return knex('themes').del()
+  return knex('reviews').del()
+  .then(function() {
+    return knex('percent_positive').del()
+  })
+  .then(function() {
+    return knex('rankings').del()
+  })
+  .then(function() {
+    return knex('themes').del()
+  })
   .then(function() {
     return knex('brands').insert([
       { brand: 'Pixel Union' },


### PR DESCRIPTION
This is to prevent any weird errors from appearing when the date is less
than an hour (Example: less than 56 minutes ago). The date isn't being
used anyway